### PR TITLE
Extract tags from ManagedClusters as labels.

### DIFF
--- a/api/v1alpha1/automatedclusterdiscovery_types.go
+++ b/api/v1alpha1/automatedclusterdiscovery_types.go
@@ -33,9 +33,14 @@ type AutomatedClusterDiscoverySpec struct {
 	// Name is the name of the cluster
 	Name string `json:"name,omitempty"`
 
-	// Type is the provider type
+	// Type is the provider type.
 	// +kubebuilder:validation:Enum=aks
 	Type string `json:"type"`
+
+	// If DisableTags is true, labels will not be applied to the generated
+	// Clusters from the tags on the upstream Clusters.
+	// +optional
+	DisableTags bool `json:"disableTags"`
 
 	AKS *AKS `json:"aks,omitempty"`
 

--- a/config/crd/bases/clusters.weave.works_automatedclusterdiscoveries.yaml
+++ b/config/crd/bases/clusters.weave.works_automatedclusterdiscoveries.yaml
@@ -62,6 +62,10 @@ spec:
                   type: string
                 description: Labels to add to all generated resources.
                 type: object
+              disableTags:
+                description: If DisableTags is true, labels will not be applied to
+                  the generated Clusters from the tags on the upstream Clusters.
+                type: boolean
               interval:
                 description: The interval at which to run the discovery
                 type: string
@@ -73,7 +77,7 @@ spec:
                   of this AutomatedClusterDiscovery.
                 type: boolean
               type:
-                description: Type is the provider type
+                description: Type is the provider type.
                 enum:
                 - aks
                 type: string

--- a/pkg/providers/azure/azure.go
+++ b/pkg/providers/azure/azure.go
@@ -60,6 +60,7 @@ func (p *AzureProvider) ListClusters(ctx context.Context) ([]*providers.Provider
 				Name:       *aksCluster.Name,
 				ID:         *aksCluster.ID,
 				KubeConfig: kubeConfig,
+				Labels:     tagsToLabels(aksCluster.Tags),
 			})
 		}
 	}
@@ -145,4 +146,14 @@ func clientFactory(subscriptionID string) (AKSClusterClient, error) {
 	}
 
 	return client, nil
+}
+
+func tagsToLabels(src map[string]*string) map[string]string {
+	labels := map[string]string{}
+
+	for k, v := range src {
+		labels[k] = *v
+	}
+
+	return labels
 }

--- a/pkg/providers/azure/azure_test.go
+++ b/pkg/providers/azure/azure_test.go
@@ -78,6 +78,9 @@ func TestClusterProvider_ListClusters(t *testing.T) {
 			{
 				ID:   to.Ptr("/subscriptions/ace37984-3d07-4051-9002-d5a52c0ae14b/resourcegroups/team-pesto-use1/providers/Microsoft.ContainerService/managedClusters/pestomarketplacetest"),
 				Name: to.Ptr("cluster-1"),
+				Tags: map[string]*string{
+					"test-tag": to.Ptr("testing"),
+				},
 			},
 		},
 	}
@@ -96,6 +99,9 @@ func TestClusterProvider_ListClusters(t *testing.T) {
 		{
 			ID:   "/subscriptions/ace37984-3d07-4051-9002-d5a52c0ae14b/resourcegroups/team-pesto-use1/providers/Microsoft.ContainerService/managedClusters/pestomarketplacetest",
 			Name: "cluster-1",
+			Labels: map[string]string{
+				"test-tag": "testing",
+			},
 		},
 	}
 	if diff := cmp.Diff(want, provided); diff != "" {

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -31,4 +31,10 @@ type ProviderCluster struct {
 	// This is likely to be a high privilege token.
 	// The token MUST NOT require the execution of a binary (ExecConfig).
 	KubeConfig *api.Config
+
+	// Labels are labels to be applied to the generated Cluster.
+	//
+	// The could be generated from Labels or Tags on the API representation of
+	// the source Cluster.
+	Labels map[string]string
 }


### PR DESCRIPTION
This pulls the tags from an AKS ManagerCluster and converts them to Labels on the generated GitOpsClusters.

